### PR TITLE
Add more detail to contact widget name

### DIFF
--- a/includes/class-contact.php
+++ b/includes/class-contact.php
@@ -22,7 +22,7 @@ final class Contact extends Base_Widget {
 
 		parent::__construct(
 			'wpcw_contact',
-			__( 'Contact', 'contact-widgets' ),
+			__( 'Contact Details', 'contact-widgets' ),
 			$widget_options
 		);
 


### PR DESCRIPTION
Change name of contact widget from 'Contact' to 'Contact Details'.