### PR TITLE
Add support for "Unsplash" (https://unsplash.com/)

### DIFF
--- a/includes/social-networks.php
+++ b/includes/social-networks.php
@@ -167,7 +167,7 @@ $fields = [
 		'select'  => $board,
 	],
 	'unsplash'     => [
-                'icon'       => 'camera',
+		'icon'       => 'camera',
 		'label'      => __( 'Unsplash', 'contact-widgets' ),
 		'default'    => "https://unsplash.com/@{$username}",
 		'select'     => $username,

--- a/includes/social-networks.php
+++ b/includes/social-networks.php
@@ -171,6 +171,5 @@ $fields = [
 		'label'      => __( 'Unsplash', 'contact-widgets' ),
 		'default'    => "https://unsplash.com/@{$username}",
 		'select'     => $username,
-		'deprecated' => false,
 	],
 ];


### PR DESCRIPTION
I added the section for 'unsplash' at the end: I forgot any preference in positioning to this regard. Had to override the icon to 'camera' as that is what they have, and there isn't an unsplash-specific one in this plugin.