### PR TITLE
Resolve conflict with Font Awesome v4

### DIFF
--- a/assets/js/fontawesome-config.js
+++ b/assets/js/fontawesome-config.js
@@ -1,0 +1,1 @@
+window.FontAwesomeConfig = { showMissingIcons: false }

--- a/assets/js/fontawesome-config.min.js
+++ b/assets/js/fontawesome-config.min.js
@@ -1,0 +1,1 @@
+window.FontAwesomeConfig={showMissingIcons:!1};

--- a/contact-widgets.php
+++ b/contact-widgets.php
@@ -108,15 +108,6 @@ if ( ! class_exists( 'Contact_Widgets' ) ) {
 		}
 
 		/**
-		 * Enqueue Font Awesome
-		 */
-		public function enqueue_font_awesome() {
-
-			wp_enqueue_script( 'font-awesome', self::$fa_url, [], '5.0.6', true );
-
-		}
-
-		/**
 		 * Load languages
 		 *
 		 * @action plugins_loaded

--- a/includes/class-base-widget.php
+++ b/includes/class-base-widget.php
@@ -572,6 +572,8 @@ abstract class Base_Widget extends \WP_Widget {
 
 		wp_enqueue_script( 'font-awesome', \Contact_Widgets::$fa_url, [], '5.0.6', true );
 
+		wp_add_inline_script( 'font-awesome', 'window.FontAwesomeConfig = { showMissingIcons: false }', 'before' );
+
 		if ( is_customize_preview() ) {
 
 			if ( ! wp_script_is( 'jquery', 'enqueued' ) ) {

--- a/includes/class-base-widget.php
+++ b/includes/class-base-widget.php
@@ -570,9 +570,9 @@ abstract class Base_Widget extends \WP_Widget {
 
 		wp_enqueue_style( 'wpcw', \Contact_Widgets::$assets_url . "css/style{$rtl}{$suffix}.css", [], Plugin::$version );
 
-		wp_enqueue_script( 'font-awesome', \Contact_Widgets::$fa_url, [], '5.0.6', true );
+		wp_enqueue_script( 'font-awesome-config', \Contact_Widgets::$assets_url . "js/fontawesome-config{$suffix}.js", [], Plugin::$version, true );
 
-		wp_add_inline_script( 'font-awesome', 'window.FontAwesomeConfig = { showMissingIcons: false }', 'before' );
+		wp_enqueue_script( 'font-awesome', \Contact_Widgets::$fa_url, [ 'font-awesome-config' ], '5.0.6', true );
 
 		if ( is_customize_preview() ) {
 

--- a/tests/phpunit/test-base-widget.php
+++ b/tests/phpunit/test-base-widget.php
@@ -40,6 +40,7 @@ final class TestBaseWidget extends TestCase {
 
 		$this->plugin->enqueue_scripts();
 
+		$this->assertContains( 'font-awesome-config', $wp_styles->queue );
 		$this->assertContains( 'font-awesome', $wp_styles->queue );
 		$this->assertContains( 'wpcw-admin', $wp_styles->queue );
 		$this->assertContains( 'wpcw-admin', $wp_scripts->queue );
@@ -55,4 +56,3 @@ final class TestBaseWidget extends TestCase {
 	}
 
 }
-

--- a/tests/phpunit/test-class-social.php
+++ b/tests/phpunit/test-class-social.php
@@ -66,6 +66,7 @@ final class TestSocial extends TestCase {
 		$wp_scripts = wp_scripts();
 
 		// Make sure the JS file is enqueued
+		$this->assertContains( 'font-awesome-config', $wp_scripts->queue );
 		$this->assertContains( 'font-awesome', $wp_scripts->queue );
 		$this->assertContains( 'wpcw', $wp_styles->queue );
 


### PR DESCRIPTION
Add Font Awesome v4 compatibility by _not_ replacing missing icons with a "?" icon. Since Font Awesome v4 icon names and prefixes changes in v5, the v4 icons are not found.

When a theme or other plugin loads Font Awesome v4 this causes some conflicts as Contact Widgets converts the icons contained in the plugin into svg icons. With `showMissingIcons: false`, the v4 icons still load when not found in v5.

See `showMissingIcons` in https://fontawesome.com/how-to-use/font-awesome-api#configuration

Note: Also remove the unused `enqueue_font_awesome` method in `contact-widgets.php`

#### Before Patch
<img src="https://cldup.com/VOxKsyIozO.png" width=350 />

#### After Patch
<img src="https://cldup.com/XV5I-MkaHx.png" width=350 />

Originally report: https://wordpress.org/support/topic/icon-interference-with-screener-plus-and-contact-widget/#post-10397141